### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,6 @@
 name: Playwright Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [main, master]


### PR DESCRIPTION
Potential fix for [https://github.com/kjanat/livedash-node/security/code-scanning/2](https://github.com/kjanat/livedash-node/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow primarily involves checking out code, installing dependencies, building, running tests, and uploading artifacts, it only requires `contents: read` permissions. This ensures the workflow adheres to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. Alternatively, it can be added specifically to the `test` job if other jobs in the workflow require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
