### PR TITLE
Fix stack in worker error responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 
 import { PrismaClient } from '@prisma/client';
 import { PrismaD1 } from '@prisma/adapter-d1';
+import { formatError } from './utils/error';
 
 export interface Env {
     DB: D1Database;
@@ -209,17 +210,7 @@ export default {
 
         } catch (error) {
             console.error('Worker error:', error);
-            const payload: Record<string, unknown> = {
-                error: 'Internal Server Error',
-                message: error instanceof Error ? error.message : 'Unknown error'
-            };
-            if (
-                typeof process !== 'undefined' &&
-                process.env?.NODE_ENV !== 'production'
-            ) {
-                payload.stack = error instanceof Error ? error.stack : undefined;
-            }
-            return new Response(JSON.stringify(payload), {
+            return new Response(JSON.stringify(formatError(error)), {
                 status: 500,
                 headers: {
                     'Content-Type': 'application/json',
@@ -229,3 +220,4 @@ export default {
         }
     },
 };
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,14 +209,17 @@ export default {
             });
 
         } catch (error) {
-            console.error('Worker error:', error);
-            return new Response(JSON.stringify(formatError(error)), {
-                status: 500,
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Access-Control-Allow-Origin': '*'
+            console.error('Worker error:', error); // Log full error details, including stack trace
+            return new Response(
+                JSON.stringify({ message: 'An internal server error occurred. Please try again later.' }),
+                {
+                    status: 500,
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Access-Control-Allow-Origin': '*'
+                    }
                 }
-            });
+            );
         }
     },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,20 +209,23 @@ export default {
 
         } catch (error) {
             console.error('Worker error:', error);
-            return new Response(
-                JSON.stringify({
-                    error: 'Internal Server Error',
-                    message: error instanceof Error ? error.message : 'Unknown error',
-                    stack: error instanceof Error ? error.stack : undefined
-                }),
-                {
-                    status: 500,
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'Access-Control-Allow-Origin': '*'
-                    },
+            const payload: Record<string, unknown> = {
+                error: 'Internal Server Error',
+                message: error instanceof Error ? error.message : 'Unknown error'
+            };
+            if (
+                typeof process !== 'undefined' &&
+                process.env?.NODE_ENV !== 'production'
+            ) {
+                payload.stack = error instanceof Error ? error.stack : undefined;
+            }
+            return new Response(JSON.stringify(payload), {
+                status: 500,
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Access-Control-Allow-Origin': '*'
                 }
-            );
+            });
         }
     },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export interface Env {
     DB: D1Database;
     NEXTAUTH_SECRET?: string;
     NEXTAUTH_URL?: string;
+    WORKER_ENV?: string; // 'development' | 'production'
 }
 
 export default {
@@ -210,8 +211,12 @@ export default {
 
         } catch (error) {
             console.error('Worker error:', error); // Log full error details, including stack trace
+            
+            // Use the formatError utility to properly format the error response
+            const errorPayload = formatError(error, env);
+            
             return new Response(
-                JSON.stringify({ message: 'An internal server error occurred. Please try again later.' }),
+                JSON.stringify(errorPayload),
                 {
                     status: 500,
                     headers: {

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,13 +1,16 @@
-export function formatError(error: unknown): Record<string, unknown> {
+export function formatError(error: unknown, env?: { WORKER_ENV?: string }): Record<string, unknown> {
   const payload: Record<string, unknown> = {
     error: 'Internal Server Error',
     message: error instanceof Error ? error.message : 'Unknown error'
   };
-  if (
-    typeof process !== 'undefined' &&
-    process.env?.NODE_ENV !== 'production'
-  ) {
+  
+  // Only include stack trace in development environment
+  // In Cloudflare Workers, check environment via env parameter
+  const isDevelopment = env?.WORKER_ENV !== 'production';
+  
+  if (isDevelopment) {
     payload.stack = error instanceof Error ? error.stack : undefined;
   }
+  
   return payload;
 }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,13 @@
+export function formatError(error: unknown): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    error: 'Internal Server Error',
+    message: error instanceof Error ? error.message : 'Unknown error'
+  };
+  if (
+    typeof process !== 'undefined' &&
+    process.env?.NODE_ENV !== 'production'
+  ) {
+    payload.stack = error instanceof Error ? error.stack : undefined;
+  }
+  return payload;
+}

--- a/tests/formatError.test.ts
+++ b/tests/formatError.test.ts
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { formatError } from '../src/utils/error';
+
+const originalEnv = process.env.NODE_ENV;
+
+test('includes stack when not in production', () => {
+  delete process.env.NODE_ENV;
+  const err = new Error('boom');
+  const payload = formatError(err);
+  assert.ok('stack' in payload);
+});
+
+test('omits stack in production', () => {
+  process.env.NODE_ENV = 'production';
+  const err = new Error('boom');
+  const payload = formatError(err);
+  assert.ok(!('stack' in payload));
+});
+
+test.after(() => {
+  if (originalEnv === undefined) delete process.env.NODE_ENV; else process.env.NODE_ENV = originalEnv;
+});

--- a/tests/formatError.test.ts
+++ b/tests/formatError.test.ts
@@ -5,17 +5,30 @@ import { formatError } from '../src/utils/error';
 const originalEnv = process.env.NODE_ENV;
 
 test('includes stack when not in production', () => {
-  delete process.env.NODE_ENV;
   const err = new Error('boom');
-  const payload = formatError(err);
+  const payload = formatError(err, { WORKER_ENV: 'development' });
   assert.ok('stack' in payload);
 });
 
 test('omits stack in production', () => {
-  process.env.NODE_ENV = 'production';
   const err = new Error('boom');
-  const payload = formatError(err);
+  const payload = formatError(err, { WORKER_ENV: 'production' });
   assert.ok(!('stack' in payload));
+});
+
+test('includes message for all environments', () => {
+  const err = new Error('boom');
+  const devPayload = formatError(err, { WORKER_ENV: 'development' });
+  const prodPayload = formatError(err, { WORKER_ENV: 'production' });
+  
+  assert.strictEqual(devPayload.message, 'boom');
+  assert.strictEqual(prodPayload.message, 'boom');
+});
+
+test('handles non-Error objects', () => {
+  const payload = formatError('string error', { WORKER_ENV: 'development' });
+  assert.strictEqual(payload.message, 'Unknown error');
+  assert.strictEqual(payload.error, 'Internal Server Error');
 });
 
 test.after(() => {


### PR DESCRIPTION
## Summary
- avoid leaking stack traces in production

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68475cb569b4832099e7d31ca12d1356